### PR TITLE
Support $GOPATH imports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
 
   gometalinter:
     build: gometalinter
-    image: teamci/gometalinter:v0.1.1
+    image: teamci/gometalinter:v0.1.2
     environment:
       TEAMCI_REPO_SLUG: ~
       TEAMCI_COMMIT: ~

--- a/gometalinter/gometalinter-tap
+++ b/gometalinter/gometalinter-tap
@@ -28,6 +28,12 @@ main() {
 	cp -vr . "${GOPATH}/src/github.com/${TEAMCI_REPO_SLUG}"
 	pushd "${GOPATH}/src/github.com/${TEAMCI_REPO_SLUG}" > /dev/null
 
+	echo '~~~~ Preparing dependencies'
+	if [ -x .teamci/gometalinter/deps ]; then
+		echo 'INFO: running provided deps install script'
+		.teamci/gometalinter/deps
+	fi
+
 	echo '~~~ Running gometalinter'
 	set +e
 	gometalinter "${gometalinter_args[@]}" ./... > "${output}"

--- a/gometalinter/gometalinter-tap
+++ b/gometalinter/gometalinter-tap
@@ -23,11 +23,18 @@ main() {
 		gometalinter_args+=(--config "${config_file}")
 	fi
 
+	echo '~~~ Preparing code for $GOPATH'
+	mkdir -p "${GOPATH}/src/github.com/${TEAMCI_REPO_SLUG}"
+	cp -vr . "${GOPATH}/src/github.com/${TEAMCI_REPO_SLUG}"
+	pushd "${GOPATH}/src/github.com/${TEAMCI_REPO_SLUG}" > /dev/null
+
 	echo '~~~ Running gometalinter'
 	set +e
 	gometalinter "${gometalinter_args[@]}" ./... > "${output}"
 	exit_code=$?
 	set -e
+
+	popd > /dev/null
 
 	if [ "${exit_code}" -ne 0 ]; then
 		tapify.rb < "${output}"

--- a/test/acceptance/gometalinter_test.bats
+++ b/test/acceptance/gometalinter_test.bats
@@ -19,6 +19,17 @@ setup() {
 	[ -n "${output}" ]
 }
 
+@test "gometalinter: deps script provided" {
+	buildkite-agent meta-data set 'teamci.repo.slug' 'gometalinter/code'
+	buildkite-agent meta-data set 'teamci.head_branch' 'deps'
+
+	run test/emulate-buildkite script/gometalinter
+
+	[ $status -eq 0 ]
+
+	echo "${output}" | grep -qF 'hello from deps script'
+}
+
 @test "gometalinter: invalid repo fails" {
 	buildkite-agent meta-data set 'teamci.repo.slug' 'gometalinter/code'
 	buildkite-agent meta-data set 'teamci.head_branch' 'fail'

--- a/test/fixtures/gometalinter/code/deps/.teamci/gometalinter/deps
+++ b/test/fixtures/gometalinter/code/deps/.teamci/gometalinter/deps
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo 'hello from deps script'

--- a/test/fixtures/gometalinter/code/deps/hello.go
+++ b/test/fixtures/gometalinter/code/deps/hello.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Println("Hello World");
+}

--- a/test/fixtures/gometalinter/code/pass/hello.go
+++ b/test/fixtures/gometalinter/code/pass/hello.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/teamci/builder/test/fixtures/gometalinter/code/pass/mypkg"
+	"github.com/gometalinter/code/mypkg"
 )
 
 func main() {


### PR DESCRIPTION
This commits puts the code into $GOPATH/src/$REPO so package specific
imports work. This is required since gometalinter parses code to detect
problems.

This poses a new question. What about dependencies not available in source control. Should TeamCI run `go get` or the equivalent to download dependencies?